### PR TITLE
Cmake fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ set(C_STANDARD_REQUIRED ON)
 if (MSVC)
     add_compile_options(/W4 /w14640 /wd4996 /WX /permissive- /Zi /Od)
 else()
-    add_compile_options(-Wall -Wextra -Werror -Wshadow -pedantic -g -O0)
+    add_compile_options(-Wall -Wextra -Werror -Wshadow -Wno-unused-function -pedantic -g -O0)
 endif()
 
 

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -202,7 +202,7 @@ TEST(ParserTestSuite, Test_Infix_Expression)
     const char *ast;    // S-expression like formatted representation of AST
   };
 
-  // TODO(HS): figure out a better way to handle the nesting of `()¬
+  // TODO(HS): figure out a better way to handle the nesting of `()`
   std::vector<Infix_Test> test_cases{
     { "1 + 1;",  0, 1, "((+ 1 1))" },
     { "1 - 1;",  0, 1, "((- 1 1))" },


### PR DESCRIPTION
Fix a few errors including
- disable a compiler warning [for clang] re unused [static] functions
- replace a char in a code comment which resulted in character encoding errors in compilation